### PR TITLE
UK public holiday data 2012 to 2019. Obtained from https://www.gov.uk…

### DIFF
--- a/events/ukhols.csv
+++ b/events/ukhols.csv
@@ -1,0 +1,66 @@
+Index,date,HolidayName
+1,25 December 2017,Christmas Day
+2,26 December 2017,Boxing Day
+3,1 January 2018,New Year’s Day
+4,30 March 2018,Good Friday
+5,2 April 2018,Easter Monday
+6,7 May 2018,Early May bank holiday
+7,28 May 2018,Spring bank holiday
+8,27 August 2018,Summer bank holiday
+9,25 December 2018,Christmas Day
+10,26 December 2018,Boxing Day
+11,1 January 2019,New Year’s Day
+12,19 April 2019,Good Friday
+13,22 April 2019,Easter Monday
+14,6 May 2019,Early May bank holiday
+15,27 May 2019 ,Spring bank holiday
+16,26 August 2019,Summer bank holiday
+17,25 December 2019,Christmas Day
+18,26 December 2019,Boxing Day
+19,28 August 2017,Summer bank holiday
+20,29 May 2017,Spring bank holiday
+21,1 May 2017,Early May bank holiday
+22,17 April 2017,Easter Monday
+23,14 April 2017,Good Friday
+24,2 January 2017,New Year’s Day
+25,27 December 2016,Christmas Day
+26,26 December 2016,Boxing Day
+27,29 August 2016,Summer bank holiday
+28,30 May 2016,Spring bank holiday
+29,2 May 2016,Early May bank holiday
+30,28 March 2016,Easter Monday
+31,25 March 2016,Good Friday
+32,1 January 2016,New Year’s Day
+33,28 December 2015,Boxing Day
+34,25 December 2015,Christmas Day
+35,31 August 2015,Summer bank holiday
+36,25 May 2015,Spring bank holiday
+37,4 May 2015,Early May bank holiday
+38,6 April 2015,Easter Monday
+39,3 April 2015,Good Friday
+40,1 January 2015,New Year’s Day
+41,26 December 2014,Boxing Day
+42,25 December 2014,Christmas Day
+43,25 August 2014,Summer bank holiday
+44,26 May 2014,Spring bank holiday
+45,5 May 2014,Early May bank holiday
+46,21 April 2014,Easter Monday
+47,18 April 2014,Good Friday
+48,1 January 2014,New Year’s Day
+49,26 December 2013,Boxing Day
+50,25 December 2013,Christmas Day
+51,26 August 2013,Summer bank holiday
+52,27 May 2013,Spring bank holiday
+53,6 May 2013,Early May bank holiday
+54,1 April 2013,Easter Monday
+55,29 March 2013,Good Friday
+56,1 January 2013,New Year’s Day
+57,26 December 2012,Boxing Day
+58,25 December 2012,Christmas Day
+59,27 August 2012,Summer bank holiday
+60,5 June 2012,Queen’s Diamond Jubilee
+61,4 June 2012,Spring bank holiday
+62,7 May 2012,Early May bank holiday
+63,9 April 2012,Easter Monday
+64,6 April 2012,Good Friday
+65,2 January 2012,New Year’s Day


### PR DESCRIPTION
…/bank-holidays